### PR TITLE
add a call to get ServerInfo, introduced in 10.1

### DIFF
--- a/client.go
+++ b/client.go
@@ -80,6 +80,16 @@ func ConvertSiteNameToContentUrl(siteName string) (string) {
 	return siteContentUrl
 }
 
+//http://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm#REST/rest_api_ref.htm#Server_Info%3FTocPath%3DAPI%2520Reference%7C__
+func (api *API) ServerInfo() (ServerInfo, error) {
+	// this call only works on apiVersion 2.4 and up
+	url := fmt.Sprintf("%s/api/%s/serverinfo", api.Server, "2.4")
+	headers := make(map[string]string)
+	retval := ServerInfoResponse{}
+	err := api.makeRequest(url, GET, nil, &retval, headers)
+	return retval.ServerInfo, err
+}
+
 //http://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm#REST/rest_api_ref.htm#Query_Sites%3FTocPath%3DAPI%2520Reference%7C_____40
 func (api *API) QuerySites() ([]Site, error) {
 	url := fmt.Sprintf("%s/api/%s/sites/", api.Server, api.Version)

--- a/model.go
+++ b/model.go
@@ -137,6 +137,15 @@ type AuthResponse struct {
 	Credentials *Credentials `json:"credentials,omitempty" xml:"credentials,omitempty"`
 }
 
+type ServerInfoResponse struct {
+	ServerInfo ServerInfo `json:"serverInfo,omitempty" xml:"serverInfo,omitempty"`
+}
+
+type ServerInfo struct {
+	ProductVersion string `json:"productVersion,omitempty" xml:"productVersion,omitempty"`
+	RestApiVersion string `json:"restApiVersion,omitempty" xml:"restApiVersion,omitempty"`
+}
+
 type QueryProjectsResponse struct {
 	Pagination Pagination `json:"pagination,omitempty" xml:"pagination,omitempty"`
 	Projects Projects `json:"projects,omitempty" xml:"projects,omitempty"`


### PR DESCRIPTION
we will use this to support MODLR-3334...finding out what versions of Tableau Server are in use.  